### PR TITLE
お知らせデータを外部から読み込むよう修正

### DIFF
--- a/api/sheet.js
+++ b/api/sheet.js
@@ -1,0 +1,29 @@
+import axios from 'axios'
+ 
+class SheetApi {
+  constructor() {
+    this.apiBase = 'https://spreadsheets.google.com/feeds/list';
+  }
+ 
+  news() {
+    return axios.get(`${this.apiBase}/1O5hfDv0hmbMQtq8T4102HPkEUs24NQKp6Ps0Y4IVpHI/od6/public/values?alt=json`)
+      .then((res) => {
+        const items = []
+        const values = Object.values(res.data.feed.entry)
+        values.forEach((value) => {
+          const item = {
+            text: value.gsx$title.$t,
+            url: value.gsx$url.$t,
+            date: value.gsx$date.$t,
+          };
+          items.push(item)
+        });
+        return items;
+      })
+      .catch(e => ({ error: e }));
+  }
+}
+ 
+const sheetApi = new SheetApi();
+ 
+export default sheetApi;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -105,6 +105,7 @@ import formatConfirmedCases from '@/utils/formatConfirmedCases'
 import News from '@/data/news.json'
 import SvgCard from '@/components/SvgCard.vue'
 import ConfirmedCasesTable from '@/components/ConfirmedCasesTable.vue'
+import sheetApi from '@/api/sheet'
 
 export default {
   components: {
@@ -117,6 +118,14 @@ export default {
     DataTable,
     SvgCard,
     ConfirmedCasesTable
+  },
+  created () {
+    this.getNews()
+  },
+  methods: {
+    async getNews () {
+      this.newsItems = await sheetApi.news()
+    }
   },
   data() {
     // 感染者数グラフ
@@ -176,7 +185,7 @@ export default {
         title: '県内の最新感染動向',
         date: Data.lastUpdate
       },
-      newsItems: News.newsItems,
+      newsItems: [],
       metroGraphOption: {
         responsive: true,
         legend: {


### PR DESCRIPTION
## 📝 関連issue
- close #71 

## ⛏ 変更内容
- スプレッドシート読み込み処理を追加（api）
- お知らせデータの変更

## 📸 スクリーンショット
![スクリーンショット 2020-03-24 18 34 51](https://user-images.githubusercontent.com/512413/77410670-9492f080-6dfe-11ea-92b3-2d9b012b7e4a.png)
