### PR TITLE
データの取得先URLを変更

### DIFF
--- a/api/sheet.js
+++ b/api/sheet.js
@@ -24,6 +24,32 @@ class SheetApi {
       .catch(e => ({ error: e }));
   }
 
+  getPatients() {
+    return axios.get(`${this.apiBase}/15CHGPTLs5aqHXq38S1RbrcTtaaOWDDosfLqvey7nh8k/3/public/values?alt=json`)
+      .then((res) => {
+        const items = []
+        const values = Object.values(res.data.feed.entry)
+        values.forEach((value) => {
+          const item = {
+            リリース日: value.gsx$リリース日.$t,
+            曜日: value.gsx$曜日.$t,
+            居住地: value.gsx$居住地.$t,
+            年代: value.gsx$年代.$t,
+            性別: value.gsx$性別.$t,
+            備考: value.gsx$備考.$t,
+            退院: value.gsx$退院.$t,
+          }
+          items.push(item)
+        });
+        const patients = {
+          data: items,
+          date: values[values.length - 1].gsx$update.$t
+        }
+        return patients;
+      })
+      .catch(e => ({ error: e }));
+  }
+
   graphData() {
     return axios.get(`${this.macroApiBase}?user_content_key=lttTvfv73JB1_0b3dWmanW_0P9DGkUcm-AfsaNdLi66LA3jZN-2LxoI61hsD1XcvX7wjJPbA-aQMU8fYuYzu_il2z3j02F4um5_BxDlH2jW0nuo2oDemN9CCS2h10ox_1xSncGQajx_ryfhECjZEnP9k53dGa_9bOh55uXRyK3KuHQRrFP7y3JXXDLFBzyALBHA50y4X5nQTHbX7VSKaSRdIug5zkO6q&lib=MkDaaQ5v_1yAZBU3X6zh8HTFkUrmYniUZ`)
       .then((res) => {

--- a/api/sheet.js
+++ b/api/sheet.js
@@ -7,7 +7,7 @@ class SheetApi {
   }
  
   news() {
-    return axios.get(`${this.apiBase}/1O5hfDv0hmbMQtq8T4102HPkEUs24NQKp6Ps0Y4IVpHI/od6/public/values?alt=json`)
+    return axios.get(`${this.apiBase}/15CHGPTLs5aqHXq38S1RbrcTtaaOWDDosfLqvey7nh8k/1/public/values?alt=json`)
       .then((res) => {
         const items = []
         const values = Object.values(res.data.feed.entry)

--- a/api/sheet.js
+++ b/api/sheet.js
@@ -6,7 +6,7 @@ class SheetApi {
     this.macroApiBase = 'https://script.googleusercontent.com/macros/echo';
   }
  
-  news() {
+  getNewsData() {
     return axios.get(`${this.apiBase}/15CHGPTLs5aqHXq38S1RbrcTtaaOWDDosfLqvey7nh8k/1/public/values?alt=json`)
       .then((res) => {
         const items = []

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -108,18 +108,16 @@ export default {
       this.patientsTable = formatTable(response.patients.data)
       this.patients.last_update = response.patients.date
       this.patients.loaded = true
+      this.sumInfoOfPatients = {
+        lText: response.patients.data.length,
+        sText: response.patients.data[response.patients.data.length - 1].リリース日 + 'の累計',
+        unit: '人'
+      }
     },
     getPatientsData (response) {
       this.patientsGraph = formatGraph(response.patients_summary.data)
       this.patients_summary.last_update = response.patients_summary.date
       this.patients_summary.loaded = true
-      this.sumInfoOfPatients = {
-        lText: this.patientsGraph[
-          this.patientsGraph.length - 1
-        ].cumulative.toLocaleString(),
-        sText: this.patientsGraph[this.patientsGraph.length - 1].label + 'の累計',
-        unit: '人'
-      }
     },
     getInspectionsData (response) {
       this.inspectionsGraph = formatGraph(response.inspections_summary.data)

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -96,21 +96,23 @@ export default {
       this.newsItems = await sheetApi.getNewsData()
     },
     async getData () {
-      await sheetApi.graphData().then(response => {
+      await sheetApi.getPatients().then(response => {
         this.getPatientsTableData(response)
+      })
+      await sheetApi.graphData().then(response => {
         this.getPatientsData(response)
         this.getInspectionsData(response)
         this.getConfirmedData(response)
         this.headerItem.date = response.lastUpdate
       })
     },
-    getPatientsTableData (response) {
-      this.patientsTable = formatTable(response.patients.data)
-      this.patients.last_update = response.patients.date
+    getPatientsTableData (patients) {
+      this.patientsTable = formatTable(patients.data)
+      this.patients.last_update = patients.date
       this.patients.loaded = true
       this.sumInfoOfPatients = {
-        lText: response.patients.data.length,
-        sText: response.patients.data[response.patients.data.length - 1].リリース日 + 'の累計',
+        lText: patients.data.length,
+        sText: patients.data[patients.data.length - 1].リリース日 + 'の累計',
         unit: '人'
       }
     },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -93,7 +93,7 @@ export default {
   },
   methods: {
     async getNews () {
-      this.newsItems = await sheetApi.news()
+      this.newsItems = await sheetApi.getNewsData()
     },
     async getData () {
       await sheetApi.graphData().then(response => {


### PR DESCRIPTION
## 📝 関連issue
- close #95 

## ⛏ 変更内容
- お知らせデータの取得先URLを変更
- 陽性患者の属性データも同様の方法に変更（表示速度向上のため）
