### PR TITLE
日付のフォーマットが異なるため事前に変更するよう修正

### DIFF
--- a/api/sheet.js
+++ b/api/sheet.js
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import dayjs from 'dayjs'
 
 class SheetApi {
   constructor() {
@@ -31,7 +32,7 @@ class SheetApi {
         const values = Object.values(res.data.feed.entry)
         values.forEach((value) => {
           const item = {
-            リリース日: value.gsx$リリース日.$t,
+            リリース日: dayjs(value.gsx$リリース日.$t).format('M/DD') ?? '不明',
             曜日: value.gsx$曜日.$t,
             居住地: value.gsx$居住地.$t,
             年代: value.gsx$年代.$t,


### PR DESCRIPTION
## 📝 関連issue
- #95 

## ⛏ 変更内容
- 月の数字が1桁の場合に対応

## 📸 スクリーンショット
一桁の場合に環境によって次のような表示になっていた
![スクリーンショット 2020-03-28 8 46 16](https://user-images.githubusercontent.com/512413/77808893-9c89b380-70d0-11ea-890e-918d5866fafe.png)

修正後
![スクリーンショット 2020-03-28 8 47 31](https://user-images.githubusercontent.com/512413/77808927-c80c9e00-70d0-11ea-9679-22f426652b49.png)
