### PR TITLE
検査陽性者の状況データの取得先とデータの読み込み順を変更した

### DIFF
--- a/api/sheet.js
+++ b/api/sheet.js
@@ -25,6 +25,52 @@ class SheetApi {
       .catch(e => ({ error: e }));
   }
 
+  graphMainSummary() {
+    return axios.get(`${this.apiBase}/15CHGPTLs5aqHXq38S1RbrcTtaaOWDDosfLqvey7nh8k/2/public/values?alt=json`)
+      .then((res) => {
+        const data = res.data.feed.entry[0]
+        const main_summary = {
+          data: {
+            attr: '検査実施件数',
+            value: Number(data.gsx$検査実施件数.$t),
+            children: [
+              {
+                attr: '陽性患者数',
+                value: Number(data.gsx$陽性患者数.$t),
+                children: [
+                  {
+                    attr: '入院中',
+                    value: Number(data.gsx$入院中.$t),
+                    children: [
+                      {
+                        attr: '軽症・中等症',
+                        value: Number(data.gsx$軽症中等症.$t),
+                      },
+                      {
+                        attr: '重症',
+                        value: Number(data.gsx$重症.$t),
+                      }
+                    ]
+                  },
+                  {
+                    attr: '退院',
+                    value: Number(data.gsx$退院.$t),
+                  },
+                  {
+                    attr: '死亡',
+                    value: Number(data.gsx$死亡.$t),
+                  }
+                ]
+              }
+            ]
+          },
+          last_update: data.gsx$lastupdate.$t,
+        }
+        return main_summary;
+      })
+      .catch(e => ({ error: e }));
+  }
+
   getPatients() {
     return axios.get(`${this.apiBase}/15CHGPTLs5aqHXq38S1RbrcTtaaOWDDosfLqvey7nh8k/3/public/values?alt=json`)
       .then((res) => {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -10,7 +10,7 @@
     />
     <v-row class="DataBlock">
       <v-col cols="12" md="6" class="DataCard">
-        <svg-card title="検査陽性者の状況" :title-id="'details-of-confirmed-cases'" :date="headerItem.date">
+        <svg-card title="検査陽性者の状況" :title-id="'details-of-confirmed-cases'" :date="confirmed.last_update">
           <pulse-loader v-if="!confirmed.loaded" :loading="!confirmed.loaded" color="#808080" />
           <confirmed-cases-table v-else v-bind="confirmedCases" />
         </svg-card>
@@ -96,18 +96,18 @@ export default {
       this.newsItems = await sheetApi.getNewsData()
     },
     async getData () {
-      await sheetApi.getPatients().then(response => {
-        this.getPatientsTableData(response)
+      await sheetApi.graphMainSummary().then(response => {
+        this.getConfirmedData(response)
+        this.headerItem.date = response.last_update
       })
       await sheetApi.getPatientsSummary().then(response => {
         this.getPatientsData(response)
       })
+      await sheetApi.getPatients().then(response => {
+        this.getPatientsTableData(response)
+      })
       await sheetApi.getInspectionsSummary().then(response => {
         this.getInspectionsData(response)
-      })
-      await sheetApi.graphData().then(response => {
-        this.getConfirmedData(response)
-        this.headerItem.date = response.lastUpdate
       })
     },
     getPatientsTableData (patients) {
@@ -130,8 +130,9 @@ export default {
       this.inspections.last_update = inspections_summary.last_update
       this.inspections.loaded = true
     },
-    getConfirmedData (response) {
-      this.confirmedCases = formatConfirmedCases(response.main_summary)
+    getConfirmedData (main_summary) {
+      this.confirmedCases = formatConfirmedCases(main_summary.data)
+      this.confirmed.last_update = main_summary.last_update
       this.confirmed.loaded = true
     },
   },
@@ -150,7 +151,8 @@ export default {
         last_update: "",
       },
       confirmed: {
-        loaded: false
+        loaded: false,
+        last_update: "",
       },
       /**
        * 全体の最終更新日


### PR DESCRIPTION
## 📝 関連issue
- close #102 

## ⛏ 変更内容
- スプレッドシートのJSONをそのまま読み込むよう修正
- グラフの表示順にデータを読み込むよう修正