### PR TITLE
Rnsk dev

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -8,10 +8,6 @@
       v-else
       :headers="chartData.headers"
       :items="chartData.datasets"
-      :items-per-page="-1"
-      :hide-default-footer="true"
-      :height="240"
-      :fixed-header="true"
       :mobile-breakpoint="0"
       class="cardTable"
     />
@@ -57,6 +53,9 @@
       }
     }
   }
+}
+.v-data-footer__select {
+  display: none;
 }
 </style>
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -27,7 +27,7 @@
           "
         />
       </v-col>
-      <v-col cols="12" md="6" class="DataCard">
+      <v-col cols="12" md="12" class="DataCard">
         <data-table
           :loaded="patients.loaded"
           :title="'陽性患者の属性'"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -41,21 +41,6 @@
           "
         />
       </v-col>
-      <v-col cols="12" md="6" class="DataCard">
-        <time-bar-chart
-          :loaded="inspections.loaded"
-          title="検査実施数"
-          :title-id="'number-of-tested'"
-          :chart-id="'time-bar-chart-inspections'"
-          :chart-data="inspectionsGraph"
-          :date="inspections.last_update"
-          :unit="'件'"
-          :info="'注：3/24登録のデータは3/12-3/24までの累計です'"
-          :url="
-            'https://www.pref.gifu.lg.jp/kinkyu-juyo-joho/shingata_corona.data/200312-2.pdf'
-          "
-        />
-      </v-col>
     </v-row>
   </div>
 </template>
@@ -104,9 +89,6 @@ export default {
       await sheetApi.getPatients().then(response => {
         this.getPatientsTableData(response)
       })
-      await sheetApi.getInspectionsSummary().then(response => {
-        this.getInspectionsData(response)
-      })
     },
     getPatientsTableData (patients) {
       this.patientsTable = formatTable(patients.data)
@@ -122,11 +104,6 @@ export default {
       this.patientsGraph = formatGraph(patients_summary.data)
       this.patients_summary.last_update = patients_summary.last_update
       this.patients_summary.loaded = true
-    },
-    getInspectionsData (inspections_summary) {
-      this.inspectionsGraph = formatGraph(inspections_summary.data)
-      this.inspections.last_update = inspections_summary.last_update
-      this.inspections.loaded = true
     },
     getConfirmedData (main_summary) {
       this.confirmedCases = formatConfirmedCases(main_summary.data)
@@ -144,10 +121,6 @@ export default {
         loaded: false,
         last_update: "",
       },
-      inspections: {
-        loaded: false,
-        last_update: "",
-      },
       confirmed: {
         loaded: false,
         last_update: "",
@@ -161,7 +134,6 @@ export default {
        */
       patientsTable: {},
       patientsGraph: [],
-      inspectionsGraph: [],
       confirmedCases: {},
       sumInfoOfPatients: {},
       headerItem: {


### PR DESCRIPTION
## 📝 関連issue
- close #110 

## ⛏ 変更内容
- 陽性患者の属性データをページング表示に変更
- 陽性患者の属性データを全幅表示に変更
- 検査実施数を削除

## 📸 スクリーンショット
![県内の最新感染動向___岐阜県_新型コロナウイルス感染症対策サイト](https://user-images.githubusercontent.com/512413/77867025-7733ab80-7270-11ea-8a5b-6285e5568279.jpg)
