### PR TITLE
「オープンデータへのリンク」の修正

### DIFF
--- a/pages/about.vue
+++ b/pages/about.vue
@@ -85,12 +85,8 @@
       当サイトに掲載されている情報は、予告なしに変更又は削除することがあります。
     </TextCard>
     <TextCard title="データについて">
-      本サイトで使用しているデータは、<a
-        href="https://www.pref.gifu.lg.jp/kinkyu-juyo-joho/shingata_corona.html"
-        target="_blank"
-        rel="noopener"
-        >岐阜県公式ホームページ</a
-      >で公開されているものです。
+      本サイトで公開しているデータは県内の行政が公開したデータをもとに作成しています。<br/>
+      各行政のサイトについては <nuxt-link :to="localePath('/municipalities')">岐阜県自治体コロナ対策情報一覧</nuxt-link>をご覧ください。
     </TextCard>
     <TextCard title="ソースコードについて">
       本サイトのソースコードはMITライセンスで公開されており、誰でも自由に利用することができます。詳しくは、<a

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -22,9 +22,6 @@
           :chart-data="patientsGraph"
           :date="patients_summary.last_update"
           :unit="'人'"
-          :url="
-            'https://www.pref.gifu.lg.jp/kinkyu-juyo-joho/shingata_corona.html'
-          "
         />
       </v-col>
       <v-col cols="12" md="12" class="DataCard">
@@ -36,9 +33,6 @@
           :chart-option="{}"
           :date="patients.last_update"
           :info="sumInfoOfPatients"
-          :url="
-            'https://www.pref.gifu.lg.jp/kinkyu-juyo-joho/shingata_corona.html'
-          "
         />
       </v-col>
     </v-row>


### PR DESCRIPTION
## 📝 関連issue
- close #119 

## ⛏ 変更内容
- 「オープンデータへのリンク」の記載を削除
- 「本サイトについて」のデータについての記載を事実に合わせて修正。
　自治体への相談窓口一覧にリンクした。

## 📸 スクリーンショット
![image](https://user-images.githubusercontent.com/15156125/78004470-18a42580-7375-11ea-9720-d4f346efeca9.png)
![image](https://user-images.githubusercontent.com/15156125/78004514-28bc0500-7375-11ea-980f-49555f68f39e.png)
![image](https://user-images.githubusercontent.com/15156125/78004620-530dc280-7375-11ea-9ac9-4dca21b90f59.png)
