### PR TITLE
感染症予防についてのページを追加

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -120,12 +120,12 @@ export default {
           icon: 'mdi-city',
           title: this.$t('岐阜県自治体コロナ対策情報一覧'),
           link: this.localePath('/municipalities'),
-          divider: true
         },
         {
-          icon: 'ParentIcon',
-          title: this.$t('for Families with children'),
-          link: this.localePath('/parent')
+          icon: 'mdi-hand-water',
+          title: this.$t('新型コロナウイルス感染症の予防について'),
+          link: this.localePath('/precaution'),
+          divider: true
         },
         {
           icon: 'mdi-domain',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -149,7 +149,7 @@ const config = {
     generate: {
         fallback: true,
         routes() {
-            const locales = ['ja', 'en', 'zh-cn', 'zh-tw', 'ko', 'ja-basic']
+            const locales = ['ja', 'en', 'ja-basic']
             const pages = [
                 '/cards/details-of-confirmed-cases',
                 '/cards/number-of-confirmed-cases',

--- a/pages/precaution.vue
+++ b/pages/precaution.vue
@@ -1,0 +1,58 @@
+<template>
+  <div class="Parent">
+    <page-header :icon="'mdi-hand-water'" :title="$t('新型コロナウイルス感染症の予防について')" />
+    <StaticCard>
+      <h3>1. {{ $t('新型コロナウイルス感染症の特徴は？') }}</h3>
+      <p>
+        {{ $t('発熱や咳が長引くこと（１週間前後）が多く、強いだるさ（倦怠感）を訴える方が多いことが特徴です。') }}
+        {{ $t('ご高齢の方や、糖尿病、心不全、呼吸器疾患（COPDなど）のある方などは重症化しやすい可能性があります。') }}
+      </p>
+    </StaticCard>
+    <StaticCard>
+      <h3>2. {{ $t('新型コロナウイルス感染症の予防方法は？') }}</h3>
+      <p>
+          {{ $t('新型コロナウイルスは、風邪やインフルエンザと同様、患者の咳などの飛沫を吸い込むことによる飛沫感染と、ウイルスが付着した手で口や鼻に触ることによる接触感染によりうつると考えられています。' )}}
+          {{ $t('また、患者とすれ違う程度では感染するリスクは低いと言われています。') }}
+      </p>
+      <p>
+        {{ $t('通常の風邪やインフルエンザの予防方法と同じく、手洗い（よく泡立てて30秒）や手指消毒剤（70％エタノール）での消毒をこまめに行うことが重要です。') }}
+        {{ $t('特に、症状がある場合には、周囲の人に感染を広げないために、マスクを着用するなどの咳エチケットが重要です。') }}
+      </p>
+    </StaticCard>
+    <StaticCard>
+      <h3>3. {{ $t('感染症を疑う場合の対応') }}</h3>
+      <p>{{ $t('次のような方は 帰国者・接触者相談センターにご相談ください。') }}</p>
+      <ol>
+        <li>{{ $t('風邪の症状や37.5℃以上の発熱が４日以上続く方（解熱剤を飲み続けなければならない方も同様）') }}</li>
+        <li>{{ $t('強いだるさ（倦怠感）や息苦しさ（呼吸困難）がある方') }}</li>
+      </ol>
+      <p>{{ $t('なお、以下のような方は重症化しやすいため、 ①の状態が２日程度続く場合には、御相談ください。') }}</p>
+      <ul>
+        <li>{{ $t('高齢者') }}</li>
+        <li>{{ $t('糖尿病、心不全、呼吸器疾患（COPD等）の基礎疾患がある方') }}</li>
+        <li>{{ $t('透析を受けている方') }}</li>
+        <li>{{ $t('免疫抑制剤や抗がん剤等を用いている方') }}</li>
+        <li>{{ $t('妊婦の方') }}</li>
+      </ul>
+    </StaticCard>
+    <static-button
+      :url="'/flow'"
+      :text="$t('相談の手順を確認する')"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import PageHeader from '@/components/PageHeader.vue'
+import StaticCard from '@/components/StaticCard.vue'
+import StaticButton from '@/components/StaticButton.vue'
+
+export default Vue.extend({
+  components: {
+    PageHeader,
+    StaticCard,
+    StaticButton
+  },
+})
+</script>


### PR DESCRIPTION
## 📝 関連issue
- close #118 

## ⛏ 変更内容
- 予防についてのページ追加
- ナビメニューリンクを修正

https://rnsk-dev-covid19.netlify.com/precaution

## 📸 スクリーンショット
![岐阜県_新型コロナウイルス感染症対策サイト___岐阜県_新型コロナウイルス感染症対策サイト](https://user-images.githubusercontent.com/512413/78326398-4081cc00-75b5-11ea-9be7-ec3b8f05fe2e.jpg)
