### PR TITLE
データ表示部の多言語化対応/ロゴの配置

### DIFF
--- a/components/MenuList.vue
+++ b/components/MenuList.vue
@@ -11,9 +11,7 @@
           <component
             :is="prefixIconTag(item.icon)"
             v-bind="prefixIconAttrs(item.icon)"
-          >
-            {{ item.icon }}
-          </component>
+          >{{ item.icon }}</component>
         </span>
         <span class="MenuList-Title">{{ item.title }}</span>
         <v-icon
@@ -23,9 +21,7 @@
           aria-label="別タブで開く"
           class="MenuList-ExternalIcon"
           size="12"
-        >
-          mdi-open-in-new
-        </v-icon>
+        >mdi-open-in-new</v-icon>
       </component>
     </li>
   </ul>
@@ -94,6 +90,7 @@ export default class MenuList extends Vue {
 
 <style lang="scss" scoped>
 .MenuList {
+  margin-top: 24px;
   padding: 12px 0;
   border-bottom: 1px solid $gray-4;
   @include largerThan($small) {
@@ -175,5 +172,4 @@ export default class MenuList extends Vue {
   margin-left: 2px;
   color: $gray-3;
 }
-
 </style>

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -5,17 +5,18 @@
         class="SideNavigation-OpenIcon"
         :aria-label="$t('サイドメニュー項目を開く')"
         @click="$emit('openNavi', $event)"
-      >
-        mdi-menu
-      </v-icon>
+      >mdi-menu</v-icon>
       <h1 class="SideNavigation-Heading">
         <nuxt-link :to="localePath('/')" class="SideNavigation-HeadingLink">
           <div class="SideNavigation-HeaderLogo">
             <img src="/logo.svg" :alt="$t('Gifu Prefectural Government')" />
           </div>
           <div class="SideNavigation-HeaderLogoLinkText">
-            {{ $t('Gifu Prefectural Government') }}<br />
-            {{ $t('COVID-19') }}<br />{{ $t('Measures site') }}
+            {{ $t('Gifu Prefectural Government') }}
+            <br />
+            {{ $t('COVID-19') }}
+            <br />
+            {{ $t('Measures site') }}
           </div>
         </nuxt-link>
       </h1>
@@ -25,20 +26,16 @@
         class="SideNavigation-CloseIcon"
         :aria-label="$t('サイドメニュー項目を閉じる')"
         @click="$emit('closeNavi', $event)"
-      >
-        mdi-close
-      </v-icon>
+      >mdi-close</v-icon>
+
+      <div class="SideNavigation-Language">
+        <label class="SideNavigation-LanguageLabel" for="LanguageSelector">{{ $t('多言語対応選択メニュー') }}</label>
+        <LanguageSelector />
+      </div>
 
       <nav class="SideNavigation-Menu">
         <MenuList :items="items" @click="$emit('closeNavi', $event)" />
       </nav>
-
-      <div class="SideNavigation-Language">
-        <label class="SideNavigation-LanguageLabel" for="LanguageSelector">
-          {{ $t('多言語対応選択メニュー') }}
-        </label>
-        <LanguageSelector />
-      </div>
 
       <footer class="SideNavigation-Footer">
         <div class="SideNavigation-Social">
@@ -80,7 +77,7 @@
           {{ $t('の下に提供されています。') }}
           <br />
           2020 Gifu Prefectural Government
-        </small> -->
+        </small>-->
       </footer>
     </div>
   </div>
@@ -114,12 +111,12 @@ export default {
         {
           icon: 'CovidIcon',
           title: this.$t('If you have any symptoms'),
-          link: this.localePath('/flow'),
+          link: this.localePath('/flow')
         },
         {
           icon: 'mdi-city',
           title: this.$t('岐阜県自治体コロナ対策情報一覧'),
-          link: this.localePath('/municipalities'),
+          link: this.localePath('/municipalities')
         },
         {
           icon: 'mdi-hand-water',
@@ -154,12 +151,13 @@ export default {
         },
         {
           title: this.$t('Other local Government'),
-          link: 'https://github.com/tokyo-metropolitan-gov/covid19/blob/development/FORKED_SITES.md'
+          link:
+            'https://github.com/tokyo-metropolitan-gov/covid19/blob/development/FORKED_SITES.md'
         },
         {
           title: this.$t('About us'),
           link: this.localePath('/about')
-        },
+        }
       ]
     }
   },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,13 +2,14 @@
   <div class="MainPage">
     <page-header :icon="headerItem.icon" :title="headerItem.title" :date="headerItem.date" />
     <whats-new :items="newsItems" />
-    <static-button
-      :url="'/flow'"
-      :text="'相談の手順を確認する'"
-    />
+    <static-button :url="'/flow'" :text="'相談の手順を確認する'" />
     <v-row class="DataBlock">
       <v-col cols="12" md="6" class="DataCard">
-        <svg-card title="検査陽性者の状況" :title-id="'details-of-confirmed-cases'" :date="confirmed.last_update">
+        <svg-card
+          title="検査陽性者の状況"
+          :title-id="'details-of-confirmed-cases'"
+          :date="confirmed.last_update"
+        >
           <pulse-loader v-if="!confirmed.loaded" :loading="!confirmed.loaded" color="#808080" />
           <confirmed-cases-table v-else v-bind="confirmedCases" />
         </svg-card>
@@ -64,15 +65,15 @@ export default {
     ConfirmedCasesTable,
     PulseLoader
   },
-  created () {
+  created() {
     this.getNews()
     this.getData()
   },
   methods: {
-    async getNews () {
+    async getNews() {
       this.newsItems = await sheetApi.getNewsData()
     },
-    async getData () {
+    async getData() {
       await sheetApi.graphMainSummary().then(response => {
         this.getConfirmedData(response)
         this.headerItem.date = response.last_update
@@ -84,8 +85,17 @@ export default {
         this.getPatientsTableData(response)
       })
     },
-    getPatientsTableData (patients) {
+    getPatientsTableData(patients) {
+      for (const row of patients.data) {
+        row['居住地'] = this.$t(row['居住地'])
+        row['年代'] = this.$t(row['年代'])
+        row['性別'] = this.$t(row['性別'])
+      }
+
       this.patientsTable = formatTable(patients.data)
+      for (const header of this.patientsTable.headers) {
+        header.text = this.$t(header.value)
+      }
       this.patients.last_update = patients.last_update
       this.patients.loaded = true
       this.sumInfoOfPatients = {
@@ -94,35 +104,35 @@ export default {
         unit: '人'
       }
     },
-    getPatientsData (patients_summary) {
+    getPatientsData(patients_summary) {
       this.patientsGraph = formatGraph(patients_summary.data)
       this.patients_summary.last_update = patients_summary.last_update
       this.patients_summary.loaded = true
     },
-    getConfirmedData (main_summary) {
+    getConfirmedData(main_summary) {
       this.confirmedCases = formatConfirmedCases(main_summary.data)
       this.confirmed.last_update = main_summary.last_update
       this.confirmed.loaded = true
-    },
+    }
   },
   data() {
     const data = {
       patients: {
         loaded: false,
-        last_update: "",
+        last_update: ''
       },
       patients_summary: {
         loaded: false,
-        last_update: "",
+        last_update: ''
       },
       confirmed: {
         loaded: false,
-        last_update: "",
+        last_update: ''
       },
       /**
        * 全体の最終更新日
        */
-      last_update: "",
+      last_update: '',
       /**
        * 各グラフ系のデータ整理後のデータ
        */
@@ -135,7 +145,7 @@ export default {
         title: '県内の最新感染動向',
         date: ''
       },
-      newsItems: [],
+      newsItems: []
     }
     return data
   },


### PR DESCRIPTION
## 📝 関連issue
- close #135
- close #137 

## ⛏ 変更内容
- データ表示部の多言語化に対応した
- 多言語化メニューをロゴの下に配置した

## 📸 スクリーンショット
![スクリーンショット 2020-04-04 22 02 53](https://user-images.githubusercontent.com/15156125/78451416-76f83d80-76c0-11ea-8ba9-e0ad3d917826.png)
![スクリーンショット 2020-04-04 22 20 19](https://user-images.githubusercontent.com/15156125/78451936-67c6bf00-76c3-11ea-85c8-c338558ccc82.png)
