### PR TITLE
一覧表の注釈を追加

### DIFF
--- a/pages/municipalities.vue
+++ b/pages/municipalities.vue
@@ -1,12 +1,13 @@
 <template>
   <div class="Municipalities">
     <page-header :icon="'mdi-city'" :title="$t('岐阜県自治体コロナ対策情報一覧')" />
+    <p class="text-right caption mb-0">({{ $t('50音順') }})</p>
     <v-card>
       <v-card-title>
         <v-text-field
           v-model="search"
           append-icon="mdi-magnify"
-          :label="$t('Search')"
+          :label="$t('自治体名またはふりがなで検索')"
           single-line
           hide-details
         ></v-text-field>


### PR DESCRIPTION
## 📝 関連issue
- close #143 

## ⛏ 変更内容
- 一覧表に50音順であることをわかるようにした
- 検索できる項目をわかるようにした

## 📸 スクリーンショット
![スクリーンショット 2020-04-08 9 49 06](https://user-images.githubusercontent.com/512413/78732678-3594b600-797e-11ea-9698-f518354f64b1.png)
