### PR TITLE
検査実施数・健康相談窓口件数・帰国者/接触者相談センター件数を追加、陽性患者数を日毎表示に変更

### DIFF
--- a/api/sheet.js
+++ b/api/sheet.js
@@ -124,13 +124,36 @@ class SheetApi {
           }
           return result;
         }, []);
-        const inspections_summary = {
-          data: group,
+        const patients_summary = {
+          data: this.addPaddingDay2Summary(group),
           last_update: dayjs(values[values.length - 1].updated.$t).format('YYYY/MM/DD HH:mm'),
         }
-        return inspections_summary;
+        return patients_summary;
       })
       .catch(e => ({ error: e }));
+  }
+
+  addPaddingDay2Summary(summary_data) {
+    var items = [];
+    var pos = 0;
+    var day_diff = dayjs(summary_data[summary_data.length - 1]['日付']).diff(summary_data[0]['日付'], 'days', false);
+
+    for (var i = 0; i < day_diff; i++) {
+      var current_day = dayjs(summary_data[0]['日付'], 'YYYY-MM-DD').add(i, 'days');
+
+      if (dayjs(summary_data[pos]['日付']).isSame(current_day)) {
+        items.push(summary_data[pos]);
+        pos++;
+      }
+      else {
+        const item = {
+          日付: current_day,
+          小計: 0,
+        }
+        items.push(item)
+      }
+    }
+    return items;
   }
 
   getInspectionsSummary() {

--- a/api/sheet.js
+++ b/api/sheet.js
@@ -6,7 +6,7 @@ class SheetApi {
     this.apiBase = 'https://spreadsheets.google.com/feeds/list';
     this.macroApiBase = 'https://script.googleusercontent.com/macros/echo';
   }
- 
+
   getNewsData() {
     return axios.get(`${this.apiBase}/15CHGPTLs5aqHXq38S1RbrcTtaaOWDDosfLqvey7nh8k/1/public/values?alt=json`)
       .then((res) => {
@@ -115,7 +115,7 @@ class SheetApi {
         const group = items.reduce((result, current) => {
           const element = result.find((p) => p.日付 === current.日付);
           if (element) {
-            element.小計 ++;
+            element.小計++;
           } else {
             result.push({
               日付: current.日付,
@@ -140,19 +140,62 @@ class SheetApi {
         const values = Object.values(res.data.feed.entry)
         values.forEach((value) => {
           const item = {
-            日付: dayjs(value.gsx$日付.$t, 'YYYY/MM/DD').format() ?? '不明',
-            小計: Number(value.gsx$実施件数.$t),
+            日付: dayjs(value.gsx$実施年月日.$t, 'YYYY/MM/DD').format() ?? '不明',
+            小計: Number(value.gsx$検査実施件数.$t),
           }
           items.push(item)
         });
         const inspections_summary = {
           data: items,
-          last_update: values[values.length - 1].gsx$updated.$t
+          last_update: dayjs(values[values.length - 1].updated.$t).format('YYYY/MM/DD HH:mm'),
         }
         return inspections_summary;
       })
       .catch(e => ({ error: e }));
   }
+
+  getCallCenterSummary() {
+    return axios.get(`${this.apiBase}/15CHGPTLs5aqHXq38S1RbrcTtaaOWDDosfLqvey7nh8k/7/public/values?alt=json`)
+      .then((res) => {
+        const items = []
+        const values = Object.values(res.data.feed.entry)
+        values.forEach((value) => {
+          const item = {
+            日付: dayjs(value.gsx$受付年月日.$t, 'YYYY/MM/DD').format() ?? '不明',
+            小計: Number(value.gsx$相談件数.$t),
+          }
+          items.push(item)
+        });
+        const callcenter_summary = {
+          data: items,
+          last_update: dayjs(values[values.length - 1].updated.$t).format('YYYY/MM/DD HH:mm'),
+        }
+        return callcenter_summary;
+      })
+      .catch(e => ({ error: e }));
+  }
+
+  getAdviceCenterSummary() {
+    return axios.get(`${this.apiBase}/15CHGPTLs5aqHXq38S1RbrcTtaaOWDDosfLqvey7nh8k/8/public/values?alt=json`)
+      .then((res) => {
+        const items = []
+        const values = Object.values(res.data.feed.entry)
+        values.forEach((value) => {
+          const item = {
+            日付: dayjs(value.gsx$受付年月日.$t, 'YYYY/MM/DD').format() ?? '不明',
+            小計: Number(value.gsx$帰国者接触者相談センター相談件数.$t),
+          }
+          items.push(item)
+        });
+        const advicecenter_summary = {
+          data: items,
+          last_update: dayjs(values[values.length - 1].updated.$t).format('YYYY/MM/DD HH:mm'),
+        }
+        return advicecenter_summary;
+      })
+      .catch(e => ({ error: e }));
+  }
+
 
   getMunicipalityLink() {
     return axios.get(`${this.apiBase}/1Dm9dsei-QXmilRN9V7IVmgnZuC8aRsFQE5RPR0-L7bI/1/public/values?alt=json`)
@@ -218,7 +261,7 @@ class SheetApi {
       .catch(e => ({ error: e }));
   }
 }
- 
+
 const sheetApi = new SheetApi();
- 
+
 export default sheetApi;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -110,18 +110,22 @@ export default {
       this.newsItems = await sheetApi.getNewsData()
     },
     async getData() {
-      await sheetApi.graphMainSummary().then(response => {
-        this.getConfirmedData(response)
-        this.headerItem.date = response.last_update
+      await sheetApi.getInspectionsSummary().then(response => {
+        this.getInspectionsData(response)
       })
+      await sheetApi
+        .graphMainSummary(
+          this.inspectionsGraph[this.inspectionsGraph.length - 1].cumulative
+        )
+        .then(response => {
+          this.getConfirmedData(response)
+          this.headerItem.date = response.last_update
+        })
       await sheetApi.getPatientsSummary().then(response => {
         this.getPatientsData(response)
       })
       await sheetApi.getPatients().then(response => {
         this.getPatientsTableData(response)
-      })
-      await sheetApi.getInspectionsSummary().then(response => {
-        this.getInspectionsData(response)
       })
       await sheetApi.getCallCenterSummary().then(response => {
         this.getCallCenterData(response)

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -36,6 +36,42 @@
           :info="sumInfoOfPatients"
         />
       </v-col>
+      <v-col cols="12" md="6" class="DataCard">
+        <time-bar-chart
+          :loaded="inspections.loaded"
+          title="検査実施数"
+          :title-id="'number-of-tested'"
+          :chart-id="'time-bar-chart-inspections'"
+          :chart-data="inspectionsGraph"
+          :date="inspections.last_update"
+          :unit="'件'"
+          :info="''"
+        />
+      </v-col>
+      <v-col cols="12" md="6" class="DataCard">
+        <time-bar-chart
+          :loaded="callcenter.loaded"
+          title="健康相談窓口相談件数"
+          :title-id="'number-of-callcenter'"
+          :chart-id="'time-bar-chart-callcenter'"
+          :chart-data="callcenterGraph"
+          :date="callcenter.last_update"
+          :unit="'件'"
+          :info="''"
+        />
+      </v-col>
+      <v-col cols="12" md="6" class="DataCard">
+        <time-bar-chart
+          :loaded="advicecenter.loaded"
+          title="帰国者・接触者相談センター相談件数"
+          :title-id="'number-of-advicecenter'"
+          :chart-id="'time-bar-chart-advicecenter'"
+          :chart-data="advicecenterGraph"
+          :date="advicecenter.last_update"
+          :unit="'件'"
+          :info="''"
+        />
+      </v-col>
     </v-row>
   </div>
 </template>
@@ -84,6 +120,15 @@ export default {
       await sheetApi.getPatients().then(response => {
         this.getPatientsTableData(response)
       })
+      await sheetApi.getInspectionsSummary().then(response => {
+        this.getInspectionsData(response)
+      })
+      await sheetApi.getCallCenterSummary().then(response => {
+        this.getCallCenterData(response)
+      })
+      await sheetApi.getAdviceCenterSummary().then(response => {
+        this.getAdviceCenterData(response)
+      })
     },
     getPatientsTableData(patients) {
       for (const row of patients.data) {
@@ -114,6 +159,21 @@ export default {
       this.confirmedCases = formatConfirmedCases(main_summary.data)
       this.confirmed.last_update = main_summary.last_update
       this.confirmed.loaded = true
+    },
+    getInspectionsData(inspections_summary) {
+      this.inspectionsGraph = formatGraph(inspections_summary.data)
+      this.inspections.last_update = inspections_summary.last_update
+      this.inspections.loaded = true
+    },
+    getCallCenterData(callcenter_summary) {
+      this.callcenterGraph = formatGraph(callcenter_summary.data)
+      this.callcenter.last_update = callcenter_summary.last_update
+      this.callcenter.loaded = true
+    },
+    getAdviceCenterData(advicecenter_summary) {
+      this.advicecenterGraph = formatGraph(advicecenter_summary.data)
+      this.advicecenter.last_update = advicecenter_summary.last_update
+      this.advicecenter.loaded = true
     }
   },
   data() {
@@ -130,6 +190,18 @@ export default {
         loaded: false,
         last_update: ''
       },
+      inspections: {
+        loaded: false,
+        last_update: ''
+      },
+      callcenter: {
+        loaded: false,
+        last_update: ''
+      },
+      advicecenter: {
+        loaded: false,
+        last_update: ''
+      },
       /**
        * 全体の最終更新日
        */
@@ -140,6 +212,9 @@ export default {
       patientsTable: {},
       patientsGraph: [],
       confirmedCases: {},
+      inspectionsGraph: [],
+      callcenterGraph: [],
+      advicecenterGraph: [],
       sumInfoOfPatients: {},
       headerItem: {
         icon: 'mdi-chart-timeline-variant',


### PR DESCRIPTION
## 📝 関連issue
- #145 
- close   #165 
https://iamakawa-covid19-datatest.netlify.com/

## ⛏ 変更内容
検査実施数・健康相談窓口件数・帰国者/接触者相談センター件数の表示を追加

## 📸 スクリーンショット
<img width="582" alt="スクリーンショット 2020-04-12 11 47 35" src="https://user-images.githubusercontent.com/15156125/79059376-3d24c980-7cb4-11ea-91e5-0342ab93e6a2.png">
<img width="586" alt="スクリーンショット 2020-04-12 11 47 42" src="https://user-images.githubusercontent.com/15156125/79059378-3f872380-7cb4-11ea-8e0e-d009b3805f44.png">
<img width="585" alt="スクリーンショット 2020-04-12 11 47 49" src="https://user-images.githubusercontent.com/15156125/79059379-40b85080-7cb4-11ea-8a69-47548b7fffbd.png">
