### PR TITLE
0パディングのバグ修正、軽症・中等症・重症の判定ロジックの変更

### DIFF
--- a/api/sheet.js
+++ b/api/sheet.js
@@ -161,7 +161,7 @@ class SheetApi {
     var pos = 0;
     var day_diff = dayjs(summary_data[summary_data.length - 1]['日付']).diff(summary_data[0]['日付'], 'days', false);
 
-    for (var i = 0; i < day_diff; i++) {
+    for (var i = 0; i <= day_diff; i++) {
       var current_day = dayjs(summary_data[0]['日付'], 'YYYY-MM-DD').add(i, 'days');
 
       if (dayjs(summary_data[pos]['日付']).isSame(current_day)) {

--- a/api/sheet.js
+++ b/api/sheet.js
@@ -41,11 +41,11 @@ class SheetApi {
             }
           }
           else {
-            if (value.gsx$患者状態.$t == '軽症') {
-              items['軽症・中等症']++;
+            if (value.gsx$患者状態.$t == '重症') {
+              items['重症']++;
             }
             else {
-              items['重症']++;
+              items['軽症・中等症']++;
             }
           }
         });

--- a/api/sheet.js
+++ b/api/sheet.js
@@ -163,17 +163,22 @@ class SheetApi {
 
     for (var i = 0; i <= day_diff; i++) {
       var current_day = dayjs(summary_data[0]['日付'], 'YYYY-MM-DD').add(i, 'days');
+      const item_padding = {
+        日付: current_day,
+        小計: 0,
+      };
+
+      if (pos >= summary_data.length) {
+        items.push(item_padding)
+        continue;
+      }
 
       if (dayjs(summary_data[pos]['日付']).isSame(current_day)) {
         items.push(summary_data[pos]);
         pos++;
       }
       else {
-        const item = {
-          日付: current_day,
-          小計: 0,
-        }
-        items.push(item)
+        items.push(item_padding)
       }
     }
     return items;


### PR DESCRIPTION
## 📝 関連issue
- close #172 
- close #174 
- close #175 

## ⛏ 変更内容
- 0パディング計算のループ条件を修正
　day_diff = データ開始日付〜データ最終日日付
　loop終了条件を   < から、<=　に変更
　例：day_diff(3/24  - 3/25)  =  1 のため、
　　　0,1の2回分処理しなくてはいけなかったが、現行プログラムは0のみしか実施していない

- 0パディングの配列外参照のバグを修正
　最終日、最終-1日、最終-2 日の検査人数がすべて0人だった場合、
　日付データが構築されない。
　※ループ最終条件として、患者データの最終番号としてあるため、原状は潜在バグ。
　   0人だった場合、例えばgetInspectionsSummaryのlast_updateなどから日付を取得する必要がある。