### PR TITLE
「陽性患者の属性」の並び順を初めから指定する

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -10,13 +10,11 @@
       :items="chartData.datasets"
       :mobile-breakpoint="0"
       class="cardTable"
+      :sort-by="sorting.sortBy"
+      :sort-desc="sorting.sortDesc"
     />
     <template v-if="loaded" v-slot:infoPanel>
-      <data-view-basic-info-panel
-        :l-text="info.lText"
-        :s-text="info.sText"
-        :unit="info.unit"
-      />
+      <data-view-basic-info-panel :l-text="info.lText" :s-text="info.sText" :unit="info.unit" />
     </template>
   </data-view>
 </template>
@@ -93,6 +91,10 @@ export default {
       type: Boolean,
       required: true,
       default: false
+    },
+    sorting: {
+      sortBy: '',
+      sortDesc: true
     }
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -34,6 +34,7 @@
           :chart-option="{}"
           :date="patients.last_update"
           :info="sumInfoOfPatients"
+          :sorting="patientsTableSorting"
         />
       </v-col>
     </v-row>
@@ -145,6 +146,10 @@ export default {
         icon: 'mdi-chart-timeline-variant',
         title: '県内の最新感染動向',
         date: ''
+      },
+      patientsTableSorting: {
+        sortBy: '日付',
+        sortDesc: true
       },
       newsItems: []
     }


### PR DESCRIPTION
## 📝 関連issue
- close #170 

## ⛏ 変更内容
- どのブラウザでも最新の陽性患者から閲覧できるよう、表示順を指定する

## 📸 スクリーンショット
![image](https://user-images.githubusercontent.com/15156125/79432313-9a977e00-8006-11ea-863f-3b29648fa490.png)
![image](https://user-images.githubusercontent.com/15156125/79432472-c31f7800-8006-11ea-8492-fcb280f8f29e.png)
