### PR TITLE
Webサイトの表示色を改善、当日の感染者数の数値表現の方法を修正

### DIFF
--- a/api/sheet.js
+++ b/api/sheet.js
@@ -184,8 +184,7 @@ class SheetApi {
       };
 
       if (pos >= summary_data.length) {
-        items.push(item_padding)
-        continue;
+        break;
       }
 
       if (dayjs(summary_data[pos]['日付']).isSame(current_day)) {

--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -1,16 +1,16 @@
 // ==================
 // color
-$blue-1: #69b6d5;
-$blue-2: #96c4d6;
-$blue-3: #6095e6;
-$blue-4: #00b5f0;
+$blue-1: #70C7EA;
+$blue-2: #0098EB;
+$blue-3: #96c4d6;
+$blue-4: #6095e6;
 $gray-1: #333333;
 $gray-2: #4d4d4d;
 $gray-3: #808080;
 $gray-4: #d9d9d9;
-$gray-5: #f8f9fa;
+$gray-5: #f9f9f9;
 $white: #ffffff;
-$link: #228b22;
+$link: #0098EA;
 // ==================
 // shadow
 $shadow: 0px 0px 2px rgba(0, 0, 0, 0.15);

--- a/components/DataSelector.vue
+++ b/components/DataSelector.vue
@@ -25,15 +25,17 @@
     border-radius: 4px !important;
     height: 24px !important;
     font-size: 12px !important;
-    color: $gray-1 !important;
-    background-color: $white !important;
+    font-weight: bold !important; 
+    color: $blue-2 !important;
+    background-color: $gray-5 !important;
     &::before {
       background-color: inherit;
     }
   }
 
   & .v-btn--active {
-    background-color: $gray-2 !important;
+    font-weight: bold !important; 
+    background-color: $blue-2 !important;
     color: $white !important;
   }
 }

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -3,7 +3,7 @@
     <template v-slot:button>
       <span />
     </template>
-    <pulse-loader v-if="!loaded" :loading="!loaded" color="#808080" />
+    <pulse-loader v-if="!loaded" :loading="!loaded" color="#70C7EA" />
     <v-data-table
       v-else
       :headers="chartData.headers"

--- a/components/MenuList.vue
+++ b/components/MenuList.vue
@@ -140,7 +140,7 @@ export default class MenuList extends Vue {
     &:focus,
     &:visited,
     &:active {
-      color: $blue-1;
+      color: $blue-2;
     }
   }
 }
@@ -154,7 +154,7 @@ export default class MenuList extends Vue {
   color: $gray-2;
 
   .nuxt-link-exact-active & {
-    color: $blue-1;
+    color: $blue-2;
   }
 }
 
@@ -164,7 +164,7 @@ export default class MenuList extends Vue {
   fill: $gray-2;
 
   .nuxt-link-exact-active & {
-    fill: $blue-1;
+    fill: $blue-2;
   }
 }
 

--- a/components/StaticButton.vue
+++ b/components/StaticButton.vue
@@ -50,7 +50,7 @@ export default class StaticButton extends Vue {
     text-decoration: none;
   }
   &:hover {
-    background-color: $blue-2;
+    background-color: $blue-3;
   }
   &-icon:before {
     color: $white;

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -3,7 +3,7 @@
     <template v-slot:button>
       <data-selector v-model="dataKind" />
     </template>
-    <pulse-loader v-if="!loaded" :loading="!loaded" color="#808080" />
+    <pulse-loader v-if="!loaded" :loading="!loaded" color="#70C7EA" />
     <bar
       v-else
       :chart-data="displayData"
@@ -122,7 +122,7 @@ export default {
               data: this.chartData.map(d => {
                 return d.transition
               }),
-              backgroundColor: '#74d8f1',
+              backgroundColor: '#70C7EA',
               borderWidth: 0
             }
           ]

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -2,7 +2,7 @@
   <v-app class="app">
     <div v-if="loading" class="loader">
       <img src="/logo.svg" alt="岐阜県" />
-      <scale-loader color="#69b6d5" />
+      <scale-loader color="#70C7EA" />
     </div>
     <div v-else class="appContainer">
       <div class="naviContainer">
@@ -118,5 +118,9 @@ export default {
     display: block;
     margin: 0 auto 20px;
   }
+}
+.v-application a
+{
+  color: $blue-2;
 }
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -10,7 +10,7 @@
           :title-id="'details-of-confirmed-cases'"
           :date="confirmed.last_update"
         >
-          <pulse-loader v-if="!confirmed.loaded" :loading="!confirmed.loaded" color="#808080" />
+          <pulse-loader v-if="!confirmed.loaded" :loading="!confirmed.loaded" color="#70C7EA" />
           <confirmed-cases-table v-else v-bind="confirmedCases" />
         </svg-card>
       </v-col>


### PR DESCRIPTION
## 📝 関連issue
- close #226
- close #227

## ⛏ 変更内容
- Webサイトの表示色を改善
- 当日分のデータが登録されていない時の感染者数のデータ表現について、
　https://github.com/CODE-for-GIFU/covid19/issues/226　に示すとおり修正
